### PR TITLE
Correting way to call async

### DIFF
--- a/wsstat/clients.py
+++ b/wsstat/clients.py
@@ -21,7 +21,7 @@ import logging
 import sys
 
 if sys.version_info < (3, 4, 4):
-    asyncio.ensure_future = asyncio.async
+    asyncio.ensure_future = getattr(asyncio, 'async')
 
 class ConnectedWebsocketConnection(object):
     def __init__(self, ws, identifier):

--- a/wsstat/demo.py
+++ b/wsstat/demo.py
@@ -7,7 +7,7 @@ import websockets
 import sys
 
 if sys.version_info < (3, 4, 4):
-    asyncio.ensure_future = asyncio.async
+    asyncio.ensure_future = getattr(asyncio, 'async')
 
 @asyncio.coroutine
 def echo_time(websocket, path):


### PR DESCRIPTION
On Python 3.7 async is a reserved keyword,so i used getattr() to get it