### PR TITLE
Fix header args with multiple colons. for example an origin header

### DIFF
--- a/wsstat/clients.py
+++ b/wsstat/clients.py
@@ -81,7 +81,7 @@ class WebsocketTestingClient(object):
         self.ring_buffer = deque(maxlen=10)
 
         if kwargs.get('header'):
-            self.extra_headers = dict([map(lambda x: x.strip(), kwargs['header'].split(':'))])
+            self.extra_headers = dict([map(lambda x: x.strip(), kwargs['header'].split(':', 1))])
 
         if kwargs.get('setup_tasks', True):
             self.setup_tasks()


### PR DESCRIPTION
If you provide a header, for example, an origin header with the format "Origin:http://127.0.0.1:8080", the script fails because there are multiple colons. adding a parameter to the split function makes it match only the first colon, the header:value separator.